### PR TITLE
MOTS-284: Removed 'parent' prefix from headers in locations table screen

### DIFF
--- a/src/webapp/js/components/locations.js
+++ b/src/webapp/js/components/locations.js
@@ -20,7 +20,7 @@ const CHIEFDOM_COLUMNS = [
     Header: 'Name',
     accessor: 'name',
   }, {
-    Header: 'Parent District',
+    Header: 'District',
     accessor: 'parent',
   },
 ];
@@ -39,7 +39,7 @@ const FACILITIES_COLUMNS = [
     Header: 'Incharge name',
     accessor: 'inchargeFullName',
   }, {
-    Header: 'Parent Chiefdom',
+    Header: 'Chiefdom',
     accessor: 'parent',
   },
 ];
@@ -49,7 +49,7 @@ const COMMUNITY_COLUMNS = [
     Header: 'Name',
     accessor: 'name',
   }, {
-    Header: 'Parent Facility',
+    Header: 'Facility',
     accessor: 'parent',
   },
 ];

--- a/src/webapp/js/container/locations-table.js
+++ b/src/webapp/js/container/locations-table.js
@@ -18,7 +18,7 @@ const COLUMNS = [
     Header: 'Name',
     accessor: 'name',
   }, {
-    Header: 'Parent District',
+    Header: 'District',
     accessor: 'parent',
   },
 ];


### PR DESCRIPTION
Removed 'parent' prefix from headers in locations table screen.
https://applab.atlassian.net/browse/MOTS-284